### PR TITLE
Index Title Support

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -35,6 +35,10 @@ function customPageTitle(hook, vm) {
 
         debug('customPageTitleOptions: ' + customPageTitleOptions);
         debug('page title [before]: ' + document.title);
+        if (!_title) {
+            customPageTitleOptions.seprator = false;
+        }
+
         if (customPageTitleOptions.prefix != '' || customPageTitleOptions.prefix != false) {
             _title = customPageTitleOptions.prefix + " " + customPageTitleOptions.seprator + " " + _title;
             debug('new title [prefix]:' + _title);

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -36,8 +36,10 @@ function customPageTitle(hook, vm) {
 
         debug('customPageTitleOptions: ' + customPageTitleOptions);
         debug('page title [before]: ' + document.title);
-        if (document.title == '') {
-            customPageTitleOptions.seprator = '';
+
+        if (document.title = '') {
+            _title = customPageTitleOptions.index;
+            debug('new title [prefix]:' + _title);
         }
 
         if (_index != customPageTitleOptions.index) {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -35,8 +35,8 @@ function customPageTitle(hook, vm) {
 
         debug('customPageTitleOptions: ' + customPageTitleOptions);
         debug('page title [before]: ' + document.title);
-        if (_title == '') {
-            customPageTitleOptions.seprator = false;
+        if (document.title == '') {
+            customPageTitleOptions.seprator = '';
         }
 
         if (customPageTitleOptions.prefix != '' || customPageTitleOptions.prefix != false) {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -35,7 +35,7 @@ function customPageTitle(hook, vm) {
 
         debug('customPageTitleOptions: ' + customPageTitleOptions);
         debug('page title [before]: ' + document.title);
-        if (!_title) {
+        if (_title == '') {
             customPageTitleOptions.seprator = false;
         }
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -16,6 +16,7 @@
 
 // config options
 const customPageTitleOptions = {
+    index: 'Docsify',
     prefix: false,
     suffix: false,
     seprator: '|',
@@ -39,14 +40,16 @@ function customPageTitle(hook, vm) {
             customPageTitleOptions.seprator = '';
         }
 
-        if (customPageTitleOptions.prefix != '' || customPageTitleOptions.prefix != false) {
-            _title = customPageTitleOptions.prefix + " " + customPageTitleOptions.seprator + " " + _title;
-            debug('new title [prefix]:' + _title);
-        }
+        if (_index != customPageTitleOptions.index) {
+            if (customPageTitleOptions.prefix != '' || customPageTitleOptions.prefix != false) {
+                _title = customPageTitleOptions.prefix + " " + customPageTitleOptions.seprator + " " + _title;
+                debug('new title [prefix]:' + _title);
+            }
 
-        if (customPageTitleOptions.suffix != '' || customPageTitleOptions.suffix != false) {
-            _title = _title + " " + customPageTitleOptions.seprator + " " + customPageTitleOptions.suffix;
-            debug('new title [suffix]:' + _title);
+            if (customPageTitleOptions.suffix != '' || customPageTitleOptions.suffix != false) {
+                _title = _title + " " + customPageTitleOptions.seprator + " " + customPageTitleOptions.suffix;
+                debug('new title [suffix]:' + _title);
+            }
         }
 
         document.title = _title;


### PR DESCRIPTION
When on the index page use the default index title as to not double up prefix/suffix. This means you can define the title in the config and this plugin will set the correct title on the index and sub pages.